### PR TITLE
Update modprobe's expected output to have a trailing space

### DIFF
--- a/cis_audit.py
+++ b/cis_audit.py
@@ -1105,7 +1105,7 @@ class CISAudit:
         cmd = f'modprobe -n -v {module} | grep -E "({module}|install)"'
         r = self._shellexec(cmd)
 
-        if r.stdout[0] == 'install /bin/true\n':
+        if r.stdout[0] == 'install /bin/true ':
             pass
         elif r.stderr[0] == f'modprobe: FATAL: Module {module} not found.\n':
             pass

--- a/tests/test_audit_kernel_module_is_disabled.py
+++ b/tests/test_audit_kernel_module_is_disabled.py
@@ -10,7 +10,8 @@ from cis_audit import CISAudit
 
 def mock_module_disabled(self, cmd):
     if 'modprobe' in cmd:
-        output = ['install /bin/true\n']
+        ## Modprobe output ends with a space, refer to https://github.com/finalduty/cis-benchmarks-audit/issues/36
+        output = ['install /bin/true ']
         error = ['']
         returncode = 0
     elif 'lsmod' in cmd:
@@ -23,7 +24,8 @@ def mock_module_disabled(self, cmd):
 
 def mock_module_enabled(self, cmd):
     if 'modprobe' in cmd:
-        output = ['insmod /lib/modules/3.10.0-1160.45.1.el7.x86_64/kernel/fs/fat/fat.ko.xz\ninsmod /lib/modules/3.10.0-1160.45.1.el7.x86_64/kernel/fs/fat/vfat.ko.xz\n']
+        ## Modprobe output ends with a space, refer to https://github.com/finalduty/cis-benchmarks-audit/issues/36
+        output = ['insmod /lib/modules/3.10.0-1160.45.1.el7.x86_64/kernel/fs/fat/fat.ko.xz\ninsmod /lib/modules/3.10.0-1160.45.1.el7.x86_64/kernel/fs/fat/vfat.ko.xz ']
         error = ['']
         returncode = 0
     elif 'lsmod' in cmd:


### PR DESCRIPTION
Updates audit_kernel_module_is_disabled to expect a trailing space instead of a newline for responses from modprobe.

Fixes #36 

**Tests**
- [x] Test that a FAIL result is returned when kernel module is not disabled
```
[root@centos7 ~]# modprobe -n -v cramfs
insmod /lib/modules/3.10.0-1160.45.1.el7.x86_64/kernel/fs/cramfs/cramfs.ko.xz 

[root@centos7 ~]# ./cis_audit.py --include 1.1.1.1
2022-05-25 10:37:50 [INFO]: Test 1.1.1.1 was explicitly included
('1', 'Initial Setup')
('1.1', 'Filesystem Configuration')
('1.1.1', 'Disable unused filesystems')
('1.1.1.1', 'Ensure mounting of cramfs is disabled', 1, 'Fail', '10ms')
```

- [x] Test that a PASS result is returned when kernel module is disabled
```
[root@centos7 ~]# echo "install cramfs /bin/true" > /etc/modprobe.d/cramfs.conf
[root@centos7 ~]# modprobe -n -v cramfs
install /bin/true 

[root@centos7 ~]# ./cis_audit.py --include 1.1.1.1
2022-05-25 10:38:42 [INFO]: Test 1.1.1.1 was explicitly included
('1', 'Initial Setup')
('1.1', 'Filesystem Configuration')
('1.1.1', 'Disable unused filesystems')
('1.1.1.1', 'Ensure mounting of cramfs is disabled', 1, 'Pass', '9ms')
```